### PR TITLE
Change parameter name to reflect units of value

### DIFF
--- a/src/satellite/time.clj
+++ b/src/satellite/time.clj
@@ -2,13 +2,13 @@
 (ns satellite.time)
 
 (defn seconds
-  [secs]
-  (* 1000 secs))
+  [ms]
+  (* 1000 ms))
 
 (defn minutes
-  [mins]
-  (* mins (seconds 60)))
+  [ms]
+  (* ms (seconds 60)))
 
 (defn hours
-  [hrs]
-  (* hrs (minutes 60)))
+  [ms]
+  (* ms (minutes 60)))


### PR DESCRIPTION
It's confusing to call the parameters the name of a different unit, particularly when you just see the signature in your editor without the comment.
