### PR TITLE
Remove dangling reference to satellite-slave.recipes.mesos

### DIFF
--- a/satellite-slave/src/satellite_slave/config.clj
+++ b/satellite-slave/src/satellite_slave/config.clj
@@ -16,7 +16,6 @@
   (:require [clj-time.periodic :refer [periodic-seq]]
             [clj-time.core :as t]
             [satellite-slave.recipes]
-            [satellite-slave.recipes.mesos]
             [satellite-slave.util :refer [every]]))
 
 (def settings


### PR DESCRIPTION
builds.
