### PR TITLE
Test now returns Riemann fragment

### DIFF
--- a/satellite-master/config/satellite-config.clj
+++ b/satellite-master/config/satellite-config.clj
@@ -6,5 +6,5 @@
      (fnk [] (url/url "http://localhost:5050"))
      :riak (fnk [] nil)
      :sleep-time (fnk [] 5000)
-     :zookeeper (fnk [] "localhost:2181")
+     :zookeeper (fnk [] "10.176.0.79:2181")
      }))

--- a/satellite-master/src/satellite/riemann/services/leader.clj
+++ b/satellite-master/src/satellite/riemann/services/leader.clj
@@ -20,10 +20,10 @@
   (start! [this]
     (locking this
       (when-not @watcher
-        (let [close-flag (atom nil)
+        (let [close (:close this)
               t (Thread. (fn []
                            (loop []
-                             (when-not @close-flag
+                             (when-not @close
                                (try
                                  (let [response (client/get
                                                  (str mesos-master-url "/master/state.json")
@@ -32,7 +32,7 @@
                                        pid (get-in response [:body "pid"])]
                                    (reset! leader (= leader-pid pid)))
                                  (catch Exception ex
-                                   (log/error (str "Requesting stats.json failed from: "
+                                   (log/error (str "Requesting state.json failed from: "
                                                    mesos-master-url)
                                               ex)))
                                (try
@@ -47,7 +47,6 @@
                           (fn [leader?]
                             leader?*))
           (deliver leader? leader?*)
-          (reset! close close-flag)
           (reset! watcher t)
           (.start t)))))
   (stop! [this]

--- a/satellite-slave/config/sample.clj
+++ b/satellite-slave/config/sample.clj
@@ -1,4 +1,4 @@
-(def mesos-work-dir "/data/scratch/local/mesos/jobs")
+(def mesos-work-dir "/tmp/mesos")
 
 (def settings
   {:satellites [{:host "satellite.master.1.example.com"}
@@ -13,12 +13,14 @@
                                                      (-> 60 t/seconds))
             (satellite-slave.recipes/num-uninterruptable-processes 10 (-> 60 t/seconds))
             (satellite-slave.recipes/load-average 30 (-> 60 t/seconds))
-            {:riemann {:ttl 300
-                       :description "example test -- number of files/dirs in cwd"}
-             :test {:command "sh -c ls | wc"
-                    :schedule (every (-> 60 t/seconds))
-                    :output (fn [{:keys [out err exit]}
-                                 (-> out
-                                     (clojure.string/split #"\s+")
-                                     first
-                                     (Integer/parseInt))])}}]})
+            {:command ["echo" "17"]
+             :schedule (every (-> 60 t/seconds))
+             :output (fn [{:keys [out err exit]}]
+                       (let [v (-> out
+                                   (clojure.string/split #"\s+")
+                                   first
+                                   (Integer/parseInt))]
+                         {:state "ok"
+                          :metric v
+                          :ttl 300
+                          :description "example test -- number of files/dirs in cwd"}))}]})

--- a/satellite-slave/src/satellite_slave/config.clj
+++ b/satellite-slave/src/satellite_slave/config.clj
@@ -26,7 +26,7 @@
    ;;
    ;; where Riemann-map is a typical Riemann map with the following default
    ;; values:
-   ;;     hostname: will be resolved by hostname(1)
+   ;;     host: will be resolved by hostname(1)
    ;;     time: will be approximately time command was run.
    ;;
    ;; and Test-map has the following schema
@@ -52,21 +52,21 @@
    ;; which is to say, either a unary function or a value. If it is function, it
    ;; is applied to the command output for the corresponding key. If it is a
    ;; value, the command output is tested for equality against it.
-   :comets [{:riemann {:hostname "dope.host"
-                       :ttl 60}
-             :test {:command "echo Hello"
-                    :output {:out "Hello\n"}
-                    :timeout 30
-                    :schedule (every (-> 3 t/seconds))}}
-            {:riemann {:ttl 40
-                       :tags ["pink" "pig"]}
-             :test {:command ["ls" "-l"]
-                    :schedule (every (-> 10 t/seconds))}}
-            {:riemann {:ttl 20
-                       :tags ["yellow" "pig"]}
-             :test {:command ["ls" "-l"]
-                    :output {:exit (fn [ret] (+ ret 17))}
-                    :schedule (every (-> 17 t/seconds))}}]
+   :comets [{:command "echo Hello"
+             :output {:out "Hello\n"}
+             :timeout 30
+             :schedule (every (-> 3 t/seconds))
+             :host "dope.host"
+             :ttl 60}
+            {:command ["ls" "-l"]
+             :schedule (every (-> 10 t/seconds))
+             :ttl 40
+             :tags ["pink" "pig"]}
+            {:command ["ls" "-l"]
+             :output {:exit (fn [ret] (+ ret 17))}
+             :schedule (every (-> 17 t/seconds))
+             :ttl 20
+             :tags ["yellow" "pig"]}]
    :safe-env true})
 
 (defn include

--- a/satellite-slave/src/satellite_slave/recipes.clj
+++ b/satellite-slave/src/satellite_slave/recipes.clj
@@ -17,100 +17,99 @@
             [clj-time.core :as t]
             [satellite-slave.util :refer [every]]))
 
-(defn make-recipe-cmd
-  [& xs]
-  (str "/home/tsram/satellite_slave" (java.io.File/separator) "satellite-recipes " (clojure.string/join " " xs)))
 
 (defn free-memory
   [threshold period]
-  {:riemann {:ttl (* 5 (.getSeconds period))
-             :service "free memory in MB"}
-   :test {:command (make-recipe-cmd "free-memory")
-          :schedule (every period)
-          :output (fn [{:keys [out err exit]}]
-                    (let [v (Integer/parseInt (clojure.string/trim out))]
-                      {:state (if (> v threshold) "ok" "critical")
-                       :metric v}))
-          :timeout 5}})
+  {:command ["satellite-recipes" "free-memory"]
+   :schedule (every period)
+   :output (fn [{:keys [out err exit]}]
+             (let [v (Integer/parseInt (clojure.string/trim out))]
+               {:ttl (* 5 (.getSeconds period))
+                :service "free memory in MB"
+                :state (if (> v threshold) "ok" "critical")
+                :metric v}))
+   :timeout 5})
 
 (defn free-swap
   [threshold period]
-  {:riemann {:ttl (* 5 (.getSeconds period))
-             :service "free swap in MB"}
-   :test {:command (make-recipe-cmd "free-swap")
-          :schedule (every period)
-          :timeout 5
-          :output (fn [{:keys [out err exit]}]
-                    (let [v (Integer/parseInt (clojure.string/trim out))]
-                      {:state (if (> v threshold) "ok" "critical")
-                       :metric v}[]))}})
+  {:command ["satellite-recipes" "free-swap"]
+   :schedule (every period)
+   :timeout 5
+   :output (fn [{:keys [out err exit]}]
+             (let [v (Integer/parseInt (clojure.string/trim out))]
+               {:ttl (* 5 (.getSeconds period))
+                :service "free swap in MB"
+                :state (if (> v threshold) "ok" "critical")
+                :metric v}))})
 
 (defn free-swap-iff-swap
   [threshold period]
-  {:riemann {:ttl (* 5 (.getSeconds period))
-             :service "free swap iff swap in MB"}
-   :test {:command (make-recipe-cmd "swap-info")
-          :schedule (every period)
-          :timeout 5
-          :output (fn [{:keys [out err exit]}]
-                    (let [->int (fn [o]
-                                  (Integer/parseInt (clojure.string/trim o)))
-                          [configured used free]
-                          (map ->int (clojure.string/split out #"\s+"))]
-                      {:state (or (= configured 0) (> free threshold))
-                       :metric free}))}})
+  {:command ["satellite-recipes" "swap-info"]
+   :schedule (every period)
+   :timeout 5
+   :output (fn [{:keys [out err exit]}]
+             (let [->int (fn [o]
+                           (Integer/parseInt (clojure.string/trim o)))
+                   [configured used free]
+                   (map ->int (clojure.string/split out #"\s+"))]
+               {:ttl (* 5 (.getSeconds period))
+                :service "free swap iff swap in MB"
+                :state (if (or (= configured 0) (> free threshold))
+                         "ok" "critical")
+                :metric free}))})
 
 (defn percentage-used
   [threshold path period]
-  {:riemann {:ttl (* 5 (.getSeconds period))
-             :service (str "percentage used of " path)}
-   :test {:command (make-recipe-cmd "percentage-used" path)
-          :schedule (every period)
-          :timeout 5
-          :output (fn [{:keys [out err exit]}]
-                    (let [v (Integer/parseInt (clojure.string/trim out))]
-                      {:state (if (< v threshold) "ok" "critical")
-                       :metric v}))}})
+  {:command ["satellite-recipes" "percentage-used" path]
+   :schedule (every period)
+   :timeout 5
+   :output (fn [{:keys [out err exit]}]
+             (let [v (Integer/parseInt (clojure.string/trim out))]
+               {:ttl (* 5 (.getSeconds period))
+                :service (str "percentage used of " path)
+                :state (if (< v threshold) "ok" "critical")
+                :metric v}))})
 
 (defn df-returns
   [timeout period]
-  {:riemann {:ttl (* 5 (.getSeconds period))
-             :service "df returns in timely fashion"}
-   :test {:command "/bin/df"
-          :schedule (every period)
-          :timeout timeout
-          :output (fn [{:keys [out exit err]}]
-                    {:state (zero? exit) "ok" "critical"
-                     :metric exit})}})
+  {:command "/bin/df"
+   :schedule (every period)
+   :timeout timeout
+   :output (fn [{:keys [out exit err]}]
+             {:ttl (* 5 (.getSeconds period))
+              :service "df returns in timely fashion"
+              :state (if (zero? exit) "ok" "critical")
+              :metric exit})})
 
 (defn num-uninterruptable-processes
   [threshold period]
-  {:riemann {:ttl (* 5 (.getSeconds period))
-             :service "number of processes in uninterruptable sleep"}
-   :test {:command (make-recipe-cmd "num-uninterruptable-processes")
-          :schedule (every period)
-          :output (fn [{:keys [out err exit]}]
-                    (let [v (Integer/parseInt (clojure.string/trim out))]
-                      {:state (if (< v threshold) "ok" "critical")
-                       :metric v}))}})
+  {:command ["satellite-recipes" "num-uninterruptable-processes"]
+   :schedule (every period)
+   :output (fn [{:keys [out err exit]}]
+             (let [v (Integer/parseInt (clojure.string/trim out))]
+               {:ttl (* 5 (.getSeconds period))
+                :service "number of processes in uninterruptable sleep"
+                :state (if (< v threshold) "ok" "critical")
+                :metric v}))})
 
 (defn load-average
   [threshold period]
-  {:riemann {:ttl (* 5 (.getSeconds period))
-             :service "load average over past 15 minutes"}
-   :test {:command (make-recipe-cmd "load-average")
-          :schedule (every period)
-          :output (fn [{:keys [out err exit]}]
-                    (let [v (Float/parseFloat (clojure.string/trim out))]
-                      {:state (< v threshold) "ok" "critical"
-                       :metric v}))}})
+  {:command ["satellite-recipes" "load-average"]
+   :schedule (every period)
+   :output (fn [{:keys [out err exit]}]
+             (let [v (Float/parseFloat (clojure.string/trim out))]
+               {:ttl (* 5 (.getSeconds period))
+                :service "load average over past 15 minutes"
+                :state (if (< v threshold) "ok" "critical")
+                :metric v}))})
 
 (defn file-exists
   [path period]
-  {:riemann {:ttl (* 5 (.getSeconds period))
-             :service (str path "exists")}
-   :test {:command (make-recipe-cmd "file-exists" path)
-          :schedule (every period)
-          :output (fn [{:keys [out err exit]}
-                       {:state (zero? exit) "ok" "critical"
-                        :metric exit}])}})
+  :riemann {}
+  {:command ["satellite-recipes" "file-exists" path]
+   :schedule (every period)
+   :output (fn [{:keys [out err exit]}]
+             {:state (if (zero? exit) "ok" "critical")
+              :metric exit
+              :ttl (* 5 (.getSeconds period))
+              :service (str path "exists")})})


### PR DESCRIPTION
The comet/test now returns the Riemann fragment rather than the test
map. This simplifies internal logic as well as the config API.
