### PR TITLE
Mf/static config option for satellite-master

### DIFF
--- a/satellite-master/README.md
+++ b/satellite-master/README.md
@@ -22,8 +22,17 @@ Make sure local-whitelist-path is pointing to your Mesos master
 whitelist. Default is /etc/mesos/whitelist.
 
 Update riemann-tcp-server-options to the server's name or IP. localhost
-is the default setting but that will not allow other servers to connect 
+is the default setting but that will not allow other servers to connect
 to the leader via Riemann.
+
+Satellite-master accepts any number of config files, specified as command line
+parameters.  Settings from the config files will be combined into a single runtime
+configuration, which is logged when Satellite starts up.  If more than one config file
+contains a value for the same config parameter, the value in rightmost file (by
+position in command line invocation) wins.
+
+Config files may be in either .clj or JSON format.  See the examples in config/.
+
 
 ## Running
 

--- a/satellite-master/config/satellite-config.clj
+++ b/satellite-master/config/satellite-config.clj
@@ -22,11 +22,9 @@
 ;; riemann-tcp-server-options. By default, it's set to localhost and will
 ;; only allow connections from localhost.
 
-(def settings
-  (merge settings
-         {:mesos-master-url (url/url "http://localhost:5050")
-          :sleep-time 5000
-          :zookeeper "localhost:2181"
-          :local-whitelist-path "/etc/mesos/whitelist"
-          :riemann-tcp-server-options {:host "localhost" }
-          :service-host "0.0.0.0"}))
+{:mesos-master-url (url/url "http://localhost:5050")
+ :sleep-time 5000
+ :zookeeper "localhost:2181"
+ :local-whitelist-path "/etc/mesos/whitelist"
+ :riemann-tcp-server-options {:host "localhost" }
+ :service-host "0.0.0.0"}

--- a/satellite-master/config/satellite-config.json
+++ b/satellite-master/config/satellite-config.json
@@ -1,0 +1,10 @@
+{
+  "mesos-master-url": "http://localhost:5050",
+  "sleep-time": 5000,
+  "zookeeper": "localhost:2181",
+  "local-whitelist-path": "/etc/mesos/whitelist",
+  "riemann-tcp-server-options": {
+    "host": "localhost"
+  },
+  "service-host": "0.0.0.0"
+}

--- a/satellite-master/src/satellite/core.clj
+++ b/satellite-master/src/satellite/core.clj
@@ -50,7 +50,7 @@
    :riemann-tcp-server-options riemann-tcp-server-schema
    :sleep-time s/Int
    :mesos-master-url cemerick.url.URL
-   :riak (s/maybe {:endpoint (s/pred clojure.java.io/as-url)
+   :riak (s/maybe {:endpoint (s/pred url/url)
                    :bucket s/Str})
    :service-host s/Str
    :service-port s/Int

--- a/satellite-master/src/satellite/core.clj
+++ b/satellite-master/src/satellite/core.clj
@@ -14,6 +14,7 @@
 
 (ns satellite.core
   (:require [cemerick.url :as url]
+            [cheshire.core :as cheshire]
             [clj-http.client :as client]
             [clj-logging-config.log4j :as log4j-conf]
             [clojurewerkz.welle.core :as wc]
@@ -210,9 +211,14 @@
                             :level :info}))
 
 (defn load-config
-  [config]
-  (log/info (str "Reading config from file: " config))
-  (load-file config))
+  [file]
+  (log/info (str "Reading config from file: " file))
+  (cond (.endsWith file ".clj")
+        (load-file file)
+        (.endsWith file ".json")
+        (cheshire/parse-stream (clojure.java.io/reader file) true)
+        :else
+        (throw (java.lang.Exception. (str "Unsupported config suffix " file)))))
 
 (defn -main
   [& args]

--- a/satellite-master/src/satellite/core.clj
+++ b/satellite-master/src/satellite/core.clj
@@ -209,15 +209,19 @@
                                   "'.'yyyy-MM-dd")
                             :level :info}))
 
+(defn load-config
+  [config]
+  (log/info (str "Reading config from file: " config))
+  (load-file config))
+
 (defn -main
-  [& [config args]]
+  [& args]
   (init-logging)
   (log/info "Starting Satellite")
-  (if (and config
-           (.exists (java.io.File. config)))
-    (do (log/info (str "Reading config from file: " config))
-        (def settings (merge settings (load-file config))))
-    (log/info (str "Using default settings" settings)))
+  (if (empty? args)
+    (log/info (str "Using default settings" settings))
+    (def settings (apply merge settings (map load-config args))))
+
   (s/validate settings-schema settings)
   ((graph/eager-compile (app (map->graph settings))) {}))
 

--- a/satellite-master/src/satellite/core.clj
+++ b/satellite-master/src/satellite/core.clj
@@ -98,6 +98,13 @@
    :whitelist-hostname-pred (fn [hostname]
                               (identity hostname))})
 
+(defn enrich-settings
+  "enrich the data types of settings values"
+  [raw-settings]
+  (assoc raw-settings :mesos-master-url
+         (when (:mesos-master-url raw-settings)
+           (-> raw-settings :mesos-master-url url/url))))
+
 (defn map->graph
   [m]
   (plumbing.core/map-vals (fn [x] (fnk [] x)) m))
@@ -226,8 +233,9 @@
   (log/info "Starting Satellite")
   (if (empty? args)
     (log/info (str "Using default settings" settings))
-    (def settings (apply merge settings (map load-config args))))
-
+    (def settings (->> (map load-config args)
+                       (apply merge settings)
+                       enrich-settings)))
   (s/validate settings-schema settings)
   ((graph/eager-compile (app (map->graph settings))) {}))
 

--- a/satellite-master/src/satellite/core.clj
+++ b/satellite-master/src/satellite/core.clj
@@ -216,7 +216,7 @@
   (if (and config
            (.exists (java.io.File. config)))
     (do (log/info (str "Reading config from file: " config))
-        (load-file config))
+        (def settings (merge settings (load-file config))))
     (log/info (str "Using default settings" settings)))
   (s/validate settings-schema settings)
   ((graph/eager-compile (app (map->graph settings))) {}))

--- a/satellite-master/src/satellite/core.clj
+++ b/satellite-master/src/satellite/core.clj
@@ -49,7 +49,7 @@
    :riemann-config (s/pred file-exists? 'file-exists?)
    :riemann-tcp-server-options riemann-tcp-server-schema
    :sleep-time s/Int
-   :mesos-master-url cemerick.url.URL
+   :mesos-master-url (s/pred url/url)
    :riak (s/maybe {:endpoint (s/pred url/url)
                    :bucket s/Str})
    :service-host s/Str


### PR DESCRIPTION
This offers the ability to use a JSON file in place of config/satellite-master.clj.  There is minimal enrichment going on here; the slave config file will be much more significant of a change when using a static document.  