### PR TITLE
satellite-master: Log more info when riemann config fails.

### DIFF
--- a/satellite-master/src/satellite/core.clj
+++ b/satellite-master/src/satellite/core.clj
@@ -193,7 +193,7 @@
                            (fn [] nil))
                    (riemann/start-riemann riemann-config)
                    (catch Throwable t
-                     (log/error "Riemann failed")
+                     (log/error t "Riemann failed")
                      (throw t))))
    :monitor (fnk [[:settings
                    sleep-time riemann-tcp-server-options]


### PR DESCRIPTION
In some configs, the stacktrace won't get logged in a place that is
visible.  This change might lead to a little extra verbosity in the
logs, for for something that prevents Satellite from even starting,
it's better to be safe than sorry.