### PR TITLE
satellite-master: Prevent error when not all task totals arrive.

### DIFF
--- a/satellite-master/src/satellite/recipes.clj
+++ b/satellite-master/src/satellite/recipes.clj
@@ -115,7 +115,7 @@
 
 (defn exceeds-threshold?
   [{divisor :metric}  {dividend :metric} threshold]
-  (and (pos? divisor)
+  (and divisor dividend (pos? divisor)
        (or (zero? dividend)
            (> (/ divisor dividend) threshold))))
 


### PR DESCRIPTION
If any of the 3 counts (failed, finished, started) are missing,
don't consider the host for black hole status.